### PR TITLE
Enable interactive wizard remotely via noVNC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,16 @@ ENV NODE_ENV=production \
     FFMPEG_PATH=/usr/bin/ffmpeg \
     FFPROBE_PATH=/usr/bin/ffprobe
 
-# System deps: browser, video tooling, virtual display, fonts
+# System deps: browser, video tooling, virtual display + VNC streaming, fonts
 RUN apt-get update && apt-get install -y --no-install-recommends \
         chromium \
         ffmpeg \
         xvfb \
         xauth \
+        x11-utils \
+        x11vnc \
+        novnc \
+        websockify \
         ca-certificates \
         fonts-liberation \
         fonts-noto-color-emoji \
@@ -59,12 +63,13 @@ COPY src ./src
 COPY next.config.js ./
 COPY generate_kokoro.py ./
 COPY project_data.json ./
+COPY deploy/entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
-EXPOSE 3456
+EXPOSE 3456 6080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD node -e "fetch('http://127.0.0.1:3456').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
-# xvfb-run provides a virtual display for headless:false browser launches
-CMD ["xvfb-run", "--auto-servernum", "--server-args=-screen 0 1920x1080x24", \
-     "node", "node_modules/next/dist/bin/next", "start", "-p", "3456"]
+# Fixed display :99 + x11vnc/noVNC streaming + Next.js (see deploy/entrypoint.sh)
+CMD ["/entrypoint.sh"]

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Container entrypoint: fixed virtual display + VNC streaming + Next.js
+#
+# - Xvfb on :99 (fixed, matches browser-session.ts ensureDisplay)
+# - x11vnc exposes the display so the interactive wizard browser can be
+#   seen and controlled remotely
+# - websockify serves noVNC on :6080 (proxied by nginx at /vnc/, behind auth)
+set -e
+
+export DISPLAY=:99
+
+Xvfb :99 -screen 0 1920x1080x24 -ac &
+
+# Wait for the display to accept connections
+i=0
+while [ $i -lt 20 ]; do
+    if xdpyinfo -display :99 >/dev/null 2>&1; then
+        break
+    fi
+    i=$((i + 1))
+    sleep 0.5
+done
+
+# VNC server attached to the virtual display (internal only; auth at nginx)
+x11vnc -display :99 -nopw -forever -shared -rfbport 5900 -quiet -bg
+
+# noVNC web client + websocket bridge
+websockify --web /usr/share/novnc 6080 localhost:5900 &
+
+exec node node_modules/next/dist/bin/next start -p 3456

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -49,6 +49,19 @@ server {
         proxy_request_buffering off;
     }
 
+    # noVNC: view/control the interactive wizard browser running on the
+    # server's virtual display. Same basic auth as the app.
+    location /vnc/ {
+        proxy_pass http://app:6080/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+
     # Runtime-generated media: Next.js production only serves public/ files
     # that existed at build time, so nginx serves these straight from disk.
     location /exports/ {


### PR DESCRIPTION
## Problem
Clicking 'launch and record steps' on the deployed app 500s: browser-session.ts checks the display with xdpyinfo (not in the image), kills the app's own Xvfb, then fails its readiness poll. Even when launched, the visible Chrome renders on the server's virtual display where nobody can see it.

## Fix
- Entrypoint starts a fixed Xvfb :99 (matching ensureDisplay's expectations) instead of xvfb-run auto-servernum, and installs x11-utils so xdpyinfo works
- x11vnc + websockify/noVNC stream the display on internal port 6080
- nginx proxies it at /vnc/ with websocket upgrade, behind the existing basic auth

## Usage
Click 'Launch & Record' in the app, then open https://tvg.333ai.tech/vnc/vnc.html?autoconnect=true&resize=scale to see and control the wizard browser.