### PR TITLE
Fix nginx config staleness on deploy + wizard window size

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,9 @@ jobs:
             rm /tmp/tvg-deploy.tar.gz
             docker compose build
             docker compose up -d
+            # Pick up nginx config changes (bind-mounted dir, needs reload)
+            docker exec tvg-nginx nginx -t
+            docker exec tvg-nginx nginx -s reload
             docker image prune -f
           '
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,16 @@ ENV NODE_ENV=production \
     FFMPEG_PATH=/usr/bin/ffmpeg \
     FFPROBE_PATH=/usr/bin/ffprobe
 
-# System deps: browser, video tooling, virtual display, fonts
+# System deps: browser, video tooling, virtual display + VNC streaming, fonts
 RUN apt-get update && apt-get install -y --no-install-recommends \
         chromium \
         ffmpeg \
         xvfb \
         xauth \
+        x11-utils \
+        x11vnc \
+        novnc \
+        websockify \
         ca-certificates \
         fonts-liberation \
         fonts-noto-color-emoji \
@@ -59,12 +63,13 @@ COPY src ./src
 COPY next.config.js ./
 COPY generate_kokoro.py ./
 COPY project_data.json ./
+COPY deploy/entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
-EXPOSE 3456
+EXPOSE 3456 6080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD node -e "fetch('http://127.0.0.1:3456').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
-# xvfb-run provides a virtual display for headless:false browser launches
-CMD ["xvfb-run", "--auto-servernum", "--server-args=-screen 0 1920x1080x24", \
-     "node", "node_modules/next/dist/bin/next", "start", "-p", "3456"]
+# Fixed display :99 + x11vnc/noVNC streaming + Next.js (see deploy/entrypoint.sh)
+CMD ["/entrypoint.sh"]

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Container entrypoint: fixed virtual display + VNC streaming + Next.js
+#
+# - Xvfb on :99 (fixed, matches browser-session.ts ensureDisplay)
+# - x11vnc exposes the display so the interactive wizard browser can be
+#   seen and controlled remotely
+# - websockify serves noVNC on :6080 (proxied by nginx at /vnc/, behind auth)
+set -e
+
+export DISPLAY=:99
+
+Xvfb :99 -screen 0 1920x1080x24 -ac &
+
+# Wait for the display to accept connections
+i=0
+while [ $i -lt 20 ]; do
+    if xdpyinfo -display :99 >/dev/null 2>&1; then
+        break
+    fi
+    i=$((i + 1))
+    sleep 0.5
+done
+
+# VNC server attached to the virtual display (internal only; auth at nginx)
+x11vnc -display :99 -nopw -forever -shared -rfbport 5900 -quiet -bg
+
+# noVNC web client + websocket bridge
+websockify --web /usr/share/novnc 6080 localhost:5900 &
+
+exec node node_modules/next/dist/bin/next start -p 3456

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -26,7 +26,7 @@ server {
 
     # Basic auth - the app has no built-in login
     auth_basic "Training Video Generator";
-    auth_basic_user_file /etc/nginx/.htpasswd;
+    auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
 
     # Large uploads (background music, voiceover audio)
     client_max_body_size 300m;

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -49,6 +49,19 @@ server {
         proxy_request_buffering off;
     }
 
+    # noVNC: view/control the interactive wizard browser running on the
+    # server's virtual display. Same basic auth as the app.
+    location /vnc/ {
+        proxy_pass http://app:6080/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+
     # Runtime-generated media: Next.js production only serves public/ files
     # that existed at build time, so nginx serves these straight from disk.
     location /exports/ {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,10 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./deploy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./deploy/.htpasswd:/etc/nginx/.htpasswd:ro
+      # Whole deploy dir (nginx.conf as conf.d/nginx.conf + .htpasswd).
+      # Directory mount (not single files): file replacements by CI tar
+      # extraction get new inodes, which stale out single-file binds.
+      - ./deploy:/etc/nginx/conf.d:ro
       # TLS certificates (issued by certbot on the host)
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - ./deploy/certbot-www:/var/www/certbot:ro

--- a/src/lib/browser-session.ts
+++ b/src/lib/browser-session.ts
@@ -106,6 +106,9 @@ export async function createBrowserSession(): Promise<Browser> {
             '--disable-accelerated-2d-canvas',
             ...(isWindows ? [] : ['--disable-gpu']),
             '--start-maximized',
+            // Xvfb has no window manager, so --start-maximized does nothing
+            // there; force the window to fill the virtual display instead
+            ...(isWindows ? [] : ['--window-size=1920,1080', '--window-position=0,0']),
         ],
     })
 


### PR DESCRIPTION
Follow-up to #5: the /vnc/ route 404'd in production because nginx's single-file bind mount went stale when CI tar extraction replaced the file inode. Mount the deploy/ directory instead, reload nginx in CI after every deploy, and size the wizard Chrome window explicitly (Xvfb has no WM, so --start-maximized is a no-op).