### PR TITLE
Clear stale Chromium profile locks before wizard launch

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -9,6 +9,11 @@ set -e
 
 export DISPLAY=:99
 
+# Clear stale Chromium profile locks: the profile lives in a persistent
+# volume, and a previous container's Chrome leaves SingletonLock stamped
+# with the old hostname, blocking launches in the new container.
+rm -f /app/.puppeteer_data/Singleton* 2>/dev/null || true
+
 Xvfb :99 -screen 0 1920x1080x24 -ac &
 
 # Wait for the display to accept connections

--- a/src/lib/browser-session.ts
+++ b/src/lib/browser-session.ts
@@ -94,6 +94,14 @@ export async function createBrowserSession(): Promise<Browser> {
 
     console.log('🚀 Launching new browser session...')
     await ensureDisplay()
+
+    // No tracked session exists, so any Singleton* lock files in the profile
+    // are stale (e.g. left by a previous container or a crashed Chrome) and
+    // would block the launch with "profile in use by another computer".
+    for (const lock of ['SingletonLock', 'SingletonCookie', 'SingletonSocket']) {
+        try { fs.rmSync(path.join(USER_DATA_DIR, lock), { force: true }) } catch { }
+    }
+
     const isWindows = process.platform === 'win32'
     const browser = await puppeteer.launch({
         headless: false, // Always visible for interactive mode


### PR DESCRIPTION
The puppeteer profile persists in a Docker volume across deploys. A replaced container leaves SingletonLock stamped with the old container hostname, so Chromium refuses to launch ('profile in use by another computer'). Clears locks at container start (entrypoint) and before creating a fresh session (browser-session.ts).