### PR TITLE
Add local browser mode for wizard recording

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     init: true
     env_file:
       - .env
+    environment:
+      # Reverse-tunnel endpoint for "local browser mode" (record-local script)
+      - LOCAL_BROWSER_URL=http://172.28.0.1:9222
     # Chromium needs a larger shared memory segment than Docker's 64MB default
     shm_size: "1gb"
     volumes:
@@ -48,3 +51,12 @@ services:
 
 volumes:
   puppeteer_profile:
+
+networks:
+  # Pinned subnet so the host-side gateway IP is stable: the record-local
+  # SSH tunnel binds the user's browser debug port on 172.28.0.1:9222
+  default:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+          gateway: 172.28.0.1

--- a/scripts/record-local.bat
+++ b/scripts/record-local.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell -ExecutionPolicy Bypass -File "%~dp0record-local.ps1"
+pause

--- a/scripts/record-local.ps1
+++ b/scripts/record-local.ps1
@@ -1,0 +1,76 @@
+# =====================================================================
+# Training Video Generator - Local Browser Mode
+#
+# Opens YOUR Chrome/Edge with a debug port and tunnels it to the VPS so
+# the wizard's "Launch & Record" drives this real local browser instead
+# of the remote one. Keep this window open while recording.
+#
+# Requirements: SSH key access to the VPS (root@45.132.240.8)
+# =====================================================================
+
+$ErrorActionPreference = "Stop"
+$VpsHost = "45.132.240.8"
+$VpsUser = "root"
+$TunnelBind = "172.28.0.1"   # docker network gateway on the VPS (pinned in docker-compose.yml)
+$DebugPort = 9222
+$AppUrl = "https://tvg.333ai.tech"
+
+Write-Host ""
+Write-Host "=== Training Video Generator - Local Browser Mode ===" -ForegroundColor Cyan
+
+# --- 1. Find a Chromium-based browser ---
+$browserCandidates = @(
+    "$env:ProgramFiles\Google\Chrome\Application\chrome.exe",
+    "${env:ProgramFiles(x86)}\Google\Chrome\Application\chrome.exe",
+    "$env:LOCALAPPDATA\Google\Chrome\Application\chrome.exe",
+    "$env:ProgramFiles\Microsoft\Edge\Application\msedge.exe",
+    "${env:ProgramFiles(x86)}\Microsoft\Edge\Application\msedge.exe"
+)
+$browser = $browserCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $browser) {
+    Write-Host "ERROR: Could not find Chrome or Edge." -ForegroundColor Red
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+Write-Host "Browser: $browser"
+
+# --- 2. Launch it with a dedicated recording profile + debug port ---
+$profileDir = Join-Path $env:LOCALAPPDATA "tvg-recorder-profile"
+Start-Process -FilePath $browser -ArgumentList @(
+    "--remote-debugging-port=$DebugPort",
+    "--user-data-dir=`"$profileDir`"",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--new-window",
+    $AppUrl
+)
+
+# --- 3. Wait for the debug port ---
+Write-Host "Waiting for browser debug port..."
+$ready = $false
+for ($i = 0; $i -lt 30; $i++) {
+    try {
+        Invoke-RestMethod -Uri "http://127.0.0.1:$DebugPort/json/version" -TimeoutSec 2 | Out-Null
+        $ready = $true; break
+    } catch { Start-Sleep -Milliseconds 500 }
+}
+if (-not $ready) {
+    Write-Host "ERROR: Browser debug port never came up." -ForegroundColor Red
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+Write-Host "Browser ready."
+
+# --- 4. Reverse tunnel: VPS docker gateway -> this PC's debug port ---
+Write-Host ""
+Write-Host "LOCAL BROWSER MODE ACTIVE" -ForegroundColor Green
+Write-Host "  - Use the app at $AppUrl (opened in the new window)"
+Write-Host "  - 'Launch & Record' will now use THIS browser"
+Write-Host "  - Keep this window open; close it (or Ctrl+C) when done"
+Write-Host ""
+
+# Blocks until interrupted; ExitOnForwardFailure aborts if the bind is taken
+ssh -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -N `
+    -R "${TunnelBind}:${DebugPort}:127.0.0.1:${DebugPort}" "$VpsUser@$VpsHost"
+
+Write-Host "Tunnel closed - local browser mode OFF (server falls back to remote browser)."

--- a/src/lib/browser-session.ts
+++ b/src/lib/browser-session.ts
@@ -54,8 +54,55 @@ async function ensureDisplay(): Promise<void> {
 const SESSION_FILE = path.resolve('./.puppeteer_session')
 const USER_DATA_DIR = path.resolve('./.puppeteer_data')
 
+// "Local browser mode": when the user runs scripts/record-local.bat on their
+// PC, it opens their own Chrome with a CDP debug port and reverse-tunnels it
+// to this address (the docker network gateway on the VPS). If reachable, the
+// wizard drives the user's real local browser instead of a server-side one.
+const LOCAL_BROWSER_URL = process.env.LOCAL_BROWSER_URL || ''
+
 interface BrowserSession {
     browserWSEndpoint: string
+    // 'local' = user's own browser over tunnel (disconnect, never close)
+    // 'server' = chromium launched on the server (close on stop)
+    mode?: 'local' | 'server'
+}
+
+function readSessionFile(): BrowserSession | null {
+    try {
+        return JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'))
+    } catch {
+        return null
+    }
+}
+
+async function tryConnectLocalBrowser(): Promise<Browser | null> {
+    if (!LOCAL_BROWSER_URL) return null
+    try {
+        const ctrl = new AbortController()
+        const timer = setTimeout(() => ctrl.abort(), 1500)
+        const res = await fetch(`${LOCAL_BROWSER_URL}/json/version`, { signal: ctrl.signal })
+        clearTimeout(timer)
+        if (!res.ok) return null
+
+        const info = await res.json() as { webSocketDebuggerUrl?: string }
+        if (!info.webSocketDebuggerUrl) return null
+
+        // Chrome reports the ws URL based on the request Host header, but
+        // normalize it to the tunnel address to be safe
+        const ws = info.webSocketDebuggerUrl.replace(
+            /^ws:\/\/[^/]+/,
+            LOCAL_BROWSER_URL.replace(/^http/, 'ws')
+        )
+
+        const browser = await puppeteer.connect({
+            browserWSEndpoint: ws,
+            defaultViewport: null,
+        })
+        console.log('🖥️  Connected to USER\'S LOCAL browser via tunnel — local mode active')
+        return browser
+    } catch {
+        return null
+    }
 }
 
 export async function getBrowserSession(): Promise<Browser | null> {
@@ -92,6 +139,18 @@ export async function createBrowserSession(): Promise<Browser> {
         return existing
     }
 
+    // Prefer the user's own local browser if the record-local tunnel is up
+    const localBrowser = await tryConnectLocalBrowser()
+    if (localBrowser) {
+        const session: BrowserSession = {
+            browserWSEndpoint: localBrowser.wsEndpoint(),
+            mode: 'local',
+        }
+        fs.writeFileSync(SESSION_FILE, JSON.stringify(session))
+        console.log(`💾 Saved local-mode browser session to ${SESSION_FILE}`)
+        return localBrowser
+    }
+
     console.log('🚀 Launching new browser session...')
     await ensureDisplay()
 
@@ -121,7 +180,8 @@ export async function createBrowserSession(): Promise<Browser> {
     })
 
     const session: BrowserSession = {
-        browserWSEndpoint: browser.wsEndpoint()
+        browserWSEndpoint: browser.wsEndpoint(),
+        mode: 'server',
     }
 
     fs.writeFileSync(SESSION_FILE, JSON.stringify(session))
@@ -132,10 +192,17 @@ export async function createBrowserSession(): Promise<Browser> {
 
 export async function closeBrowserSession() {
     try {
+        const sessionInfo = readSessionFile()
         const browser = await getBrowserSession()
         if (browser) {
-            console.log('🛑 Closing browser session...')
-            await browser.close()
+            if (sessionInfo?.mode === 'local') {
+                // The user's own browser - detach but never close their window
+                console.log('🛑 Detaching from local browser (leaving it open)...')
+                browser.disconnect()
+            } else {
+                console.log('🛑 Closing browser session...')
+                await browser.close()
+            }
         }
     } catch (error) {
         console.error('Error closing browser:', error)


### PR DESCRIPTION
Restores the original local-browser UX while keeping the web deployment: a launcher script on the user's PC opens their own Chrome with a debug port and SSH-reverse-tunnels it to the VPS (sshd GatewayPorts clientspecified, bind on pinned docker gateway 172.28.0.1). browser-session.ts prefers the tunneled browser and falls back to the server-side Chromium + noVNC. Local sessions disconnect instead of closing the user's window.