### PR TITLE
Fix duplicate start_recording crash on second wizard step

### DIFF
--- a/src/app/api/wizard/capture/route.ts
+++ b/src/app/api/wizard/capture/route.ts
@@ -81,7 +81,12 @@ async function waitForWizardInteraction(browser: any, mode: 'snapshot' | 'video'
 
                         if (interaction === 'start_recording') {
                             console.log('Wizard: Starting screen recorder...');
-                            await startRecording(page);
+                            const webPath = await startRecording(page);
+                            // Clear the interaction flag on the page immediately so
+                            // concurrent capture poll requests don't re-detect it
+                            await page.evaluate(() => {
+                                (window as any)._GEMINI_WIZARD_INTERACTION = null;
+                            }).catch(() => {});
                             return { action: 'started_recording', title: await page.title() };
                         }
 

--- a/src/lib/video-recorder.ts
+++ b/src/lib/video-recorder.ts
@@ -19,7 +19,11 @@ const RECORDINGS_DIR = path.join(process.cwd(), 'public', 'recordings');
 
 export async function startRecording(page: Page): Promise<string> {
     if (currentRecorder) {
-        throw new Error('A recording is already in progress');
+        // Already recording — return the current path rather than crashing.
+        // This happens when the app fires a second /capture poll request
+        // while the first recording is still in progress.
+        debugLog(`[Video] startRecording called but already recording — ignoring duplicate`);
+        return currentVideoPath ? `/recordings/${path.basename(currentVideoPath)}` : '';
     }
 
     if (!fs.existsSync(RECORDINGS_DIR)) {


### PR DESCRIPTION
Concurrent /capture poll requests both detected start_recording before either cleared the browser flag. Now explicitly clears the flag on the page after detecting it, and startRecording returns gracefully instead of throwing if already in progress.