### PR TITLE
Show analyzing state immediately when recording stops

### DIFF
--- a/src/app/api/wizard/capture/route.ts
+++ b/src/app/api/wizard/capture/route.ts
@@ -4,6 +4,7 @@ import { getBrowserSession } from '@/lib/browser-session'
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import { processAndAnalyzeVideo } from '@/lib/video-analysis'
 import { startRecording } from '@/lib/video-recorder'
+import { setWizardStatus } from '@/lib/wizard-status'
 import path from 'path'
 import fs from 'fs'
 
@@ -87,6 +88,7 @@ async function waitForWizardInteraction(browser: any, mode: 'snapshot' | 'video'
                             await page.evaluate(() => {
                                 (window as any)._GEMINI_WIZARD_INTERACTION = null;
                             }).catch(() => {});
+                            setWizardStatus('recording')
                             return { action: 'started_recording', title: await page.title() };
                         }
 
@@ -95,6 +97,7 @@ async function waitForWizardInteraction(browser: any, mode: 'snapshot' | 'video'
                             // before ffmpeg flushes — keeps the overlay out of
                             // the last frames of the recording
                             await new Promise(r => setTimeout(r, 400));
+                            setWizardStatus('analyzing')
                             return { action: 'stop_recording', page };
                         }
 
@@ -280,6 +283,7 @@ export async function POST(request: NextRequest) {
             console.log('Wizard: Browser triggered STOP. Processing analysis...');
             const pageTitle = await result.page.title().catch(() => 'Recorded Step');
             const data = await processAndAnalyzeVideo(pageTitle);
+            setWizardStatus('idle')
             return NextResponse.json(data);
         }
 

--- a/src/app/api/wizard/status/route.ts
+++ b/src/app/api/wizard/status/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+import { getWizardStatus } from '@/lib/wizard-status'
+
+export async function GET() {
+    return NextResponse.json({ status: getWizardStatus() })
+}

--- a/src/components/WizardOverlay.tsx
+++ b/src/components/WizardOverlay.tsx
@@ -112,13 +112,27 @@ export default function WizardOverlay({ isOpen, onClose, onAddStep, initialUrl }
         addLog(`Mode: ${mode === 'snapshot' ? 'Snapshots' : 'Video Recording'}`)
         addLog('Waiting for you to click "Capture" in the browser...')
 
+        // Poll the status endpoint while this fetch is running so the UI
+        // can transition to 'analyzing' the moment the server detects a stop,
+        // without waiting for the full AI response to come back.
+        let statusPoller: ReturnType<typeof setInterval> | null = null
+        const startStatusPoller = () => {
+            statusPoller = setInterval(async () => {
+                try {
+                    const s = await fetch('/api/wizard/status').then(r => r.json())
+                    if (s.status === 'analyzing') {
+                        setState('analyzing')
+                        addLog('Gemini is watching your clip — generating narration...')
+                    }
+                } catch { }
+            }, 800)
+        }
+
         try {
-            // This is the snapshot loop. If we are in video mode, we might handle it differently.
-            // But for now, let's keep the capture route as the primary "listening" route.
             const res = await fetch('/api/wizard/capture', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ mode, reset }) // Tell backend if we want snapshot or video trigger
+                body: JSON.stringify({ mode, reset })
             })
 
             if (!res.ok) {
@@ -131,7 +145,9 @@ export default function WizardOverlay({ isOpen, onClose, onAddStep, initialUrl }
             if (data.action === 'started_recording') {
                 addLog('Recording started in browser!')
                 setState('recording')
-                // IMPORTANT: Immediately start waiting for the STOP interaction
+                // Immediately start waiting for the STOP interaction,
+                // with the status poller active to catch the analyzing transition
+                startStatusPoller()
                 waitForCapture()
                 return;
             }
@@ -151,6 +167,7 @@ export default function WizardOverlay({ isOpen, onClose, onAddStep, initialUrl }
             setError('Session interrupted.')
             setState('error')
         } finally {
+            if (statusPoller) clearInterval(statusPoller)
             setIsCapturing(false)
         }
     }

--- a/src/lib/wizard-status.ts
+++ b/src/lib/wizard-status.ts
@@ -1,0 +1,6 @@
+// Shared in-process wizard status flag.
+// Set by the capture route, read by the status route.
+let _status: 'idle' | 'recording' | 'analyzing' = 'idle'
+
+export function setWizardStatus(s: typeof _status) { _status = s }
+export function getWizardStatus() { return _status }


### PR DESCRIPTION
Polls a lightweight status endpoint so the 'Gemini is watching your clip' spinner appears the moment stop is detected, not after the 15-30s AI call completes.