### PR TITLE
Fix analyzing notification + clean session-end handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ test-ffmpeg.js
 setup-kokoro.js
 *-debug.log
 wizard_debug.log
+.wizard-status
 
 # Python Cache
 __pycache__/

--- a/src/app/api/wizard/stop/route.ts
+++ b/src/app/api/wizard/stop/route.ts
@@ -1,11 +1,13 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { closeBrowserSession } from '@/lib/browser-session'
+import { clearWizardStatus } from '@/lib/wizard-status'
 
 export async function POST(request: NextRequest) {
     try {
         console.log('Wizard: Stop request')
         await closeBrowserSession()
+        clearWizardStatus()
         return NextResponse.json({ success: true, status: 'stopped' })
     } catch (error) {
         console.error('Wizard Stop Error:', error)

--- a/src/components/WizardOverlay.tsx
+++ b/src/components/WizardOverlay.tsx
@@ -162,10 +162,17 @@ export default function WizardOverlay({ isOpen, onClose, onAddStep, initialUrl }
             addLog(`Captured: ${data.title}`)
             setCurrentResult(data)
             setState('review')
-        } catch (err) {
-            addLog(`Error: ${err}`)
-            setError('Session interrupted.')
-            setState('error')
+        } catch (err: any) {
+            // A 404 means the browser session was closed cleanly (user hit
+            // "Finish & Close Session" while a reset poll was in-flight).
+            // Treat it as a normal end rather than an error.
+            if (err?.message?.includes('404') || String(err).includes('No active browser')) {
+                setState('idle')
+            } else {
+                addLog(`Error: ${err}`)
+                setError('Session interrupted.')
+                setState('error')
+            }
         } finally {
             if (statusPoller) clearInterval(statusPoller)
             setIsCapturing(false)

--- a/src/lib/wizard-status.ts
+++ b/src/lib/wizard-status.ts
@@ -1,6 +1,22 @@
-// Shared in-process wizard status flag.
-// Set by the capture route, read by the status route.
-let _status: 'idle' | 'recording' | 'analyzing' = 'idle'
+import path from 'path'
+import fs from 'fs'
 
-export function setWizardStatus(s: typeof _status) { _status = s }
-export function getWizardStatus() { return _status }
+// Filesystem-based wizard status flag.
+// A module-level variable doesn't work across Next.js route handlers because
+// each handler may run in a separate worker context. Writing to a temp file
+// guarantees all routes see the same state.
+const STATUS_FILE = path.join(process.cwd(), '.wizard-status')
+
+type WizardStatus = 'idle' | 'recording' | 'analyzing'
+
+export function setWizardStatus(s: WizardStatus) {
+    try { fs.writeFileSync(STATUS_FILE, s, 'utf-8') } catch { }
+}
+
+export function getWizardStatus(): WizardStatus {
+    try { return fs.readFileSync(STATUS_FILE, 'utf-8').trim() as WizardStatus } catch { return 'idle' }
+}
+
+export function clearWizardStatus() {
+    try { fs.rmSync(STATUS_FILE, { force: true }) } catch { }
+}


### PR DESCRIPTION
Three fixes from log analysis:

1. **Analyzing notification never showed** — wizard-status.ts used a module-level variable which isn't shared across Next.js route handler workers in dev/prod. Replaced with a .wizard-status temp file (same pattern as .puppeteer_session).

2. **ECONNREFUSED error after session close** — the UI fired a reset capture poll after the video result was shown, but Chrome was already closed. The 404 response was treated as a crash. Now treated as a clean session end → idle state.

3. **Stale status flag** — wizard/stop now calls clearWizardStatus() so the next session starts clean.